### PR TITLE
Changing the stroke of svg tag- solving the bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,7 +98,7 @@
 
         <div class="footer-right">
             <div class="footer-right-box">
-                <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="#1d1d1d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M12 3v12" />
                         <polyline points="5 9 12 2 19 9"/>
                     <path d="M5 20h14" />
@@ -109,7 +109,7 @@
             </div>
             <div class="footer-right-box">
 
-                <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="#1d1d1d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M3 6h5l2 3h11v11H3z" />
                     <path d="M3 6v12a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V9a2 2 0 0 0-2-2H10l-2-3H3z" />
                 </svg>
@@ -120,7 +120,7 @@
             </div>
             <div class="footer-right-box">
 
-                <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="#1d1d1d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" fill="none" stroke="#e0e0e0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M20 12L12 20a2 2 0 0 1-2.8 0L4 14.8a2 2 0 0 1 0-2.8L12 4l8 8z" />
                     <circle cx="16" cy="8" r="1.5" />
                 </svg>


### PR DESCRIPTION
I have try to solve the bug of the svg tag that are not showing in the light theme #39 . There is only a slight change. Previously it was stroke : #1d1d1d which is matched with the background and unable to see . but after changing the stroke:#e0e0e0 now it is completely visible and contrast to the background. Fixes #39 

`<svg .... stroke="#e0e0e0" .....">` change in this.