### PR TITLE
Added full frontend project with .gitignore for future backend setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Ignore node_modules if using npm/yarn in the future
+node_modules/
+
+# Build artifacts
+dist/
+build/
+
+# SCSS cache
+.sass-cache/
+
+# Logs
+*.log
+
+# System files
+.DS_Store
+Thumbs.db
+
+# Environment files (in case added later)
+.env
+.env.*
+
+# Map files (optional)
+*.map


### PR DESCRIPTION
### Summary

This PR adds a `.gitignore` file and completes the initial setup for the frontend structure of the `notesvault-GSSoC` project.

### What’s Included

- Added `.gitignore` to ensure unnecessary files (like `node_modules`, `.env`, log files, etc.) are not committed accidentally.
- Structured the project folder for frontend development using standard best practices.
- Ensured no confidential or environment-specific files are tracked.
- Clean and minimal base ready for development and contribution.

### Why This Is Important

- Currently, the project is frontend-only, but there is a possibility of backend integration in the future.
- By proactively adding a `.gitignore` now, it prepares the repo for scalability and prevents clutter or accidental exposure of sensitive files.
- Encourages contributors to follow clean development workflows and maintain repo hygiene from the start.

### Future Consideration

- If backend tools like Node.js, Express, or APIs are added later, this `.gitignore` already covers related files.
- More ignore rules can be added in the future if we introduce testing tools, CI/CD pipelines, or deployment scripts.

