### PR TITLE
Fix: Removed the arrow below footer.

### DIFF
--- a/index.html
+++ b/index.html
@@ -211,12 +211,6 @@
 
 <!-- Footer -->
 
-<!-- 🔺 Place Scroll Button OUTSIDE the .footer-container -->
-<button id="scrollToTopBtn" title="Go to top">
-  <i class="fas fa-arrow-up"></i>
-</button>
-
-
 <script>
   document.getElementById("year").textContent = new Date().getFullYear();
 </script>


### PR DESCRIPTION
In this PR, I’ve removed the small arrow icon that was showing up below the footer. It wasn’t really needed and was making the desktop layout look a bit off.

What I changed:
Removed the arrow below the footer

Cleaned up the extra spacing caused by it

Now the page looks much cleaner, especially on larger screens.
Let me know if anything else needs to be tweaked!