### PR TITLE
Added Hover Effect to Footer Links

### DIFF
--- a/index.html
+++ b/index.html
@@ -321,9 +321,7 @@
             "
           >
             <li>
-              <a
-                href="pages/upload.html"
-                style="text-decoration: none; color: white"
+              <a href="pages/upload.html" class="footer-link"
                 ><i
                   class="fas fa-upload"
                   style="color: #4caf50; margin-right: 10px"
@@ -332,9 +330,7 @@
               >
             </li>
             <li>
-              <a
-                href="pages/search.html"
-                style="text-decoration: none; color: white"
+              <a href="pages/search.html" class="footer-link"
                 ><i
                   class="fas fa-tags"
                   style="color: #ff9800; margin-right: 10px"
@@ -343,9 +339,7 @@
               >
             </li>
             <li>
-              <a
-                href="pages/overview.html"
-                style="text-decoration: none; color: white"
+              <a href="pages/overview.html" class="footer-link"
                 ><i
                   class="fas fa-folder-open"
                   style="color: #03a9f4; margin-right: 10px"
@@ -354,9 +348,7 @@
               >
             </li>
             <li>
-              <a
-                href="pages/todolist.html"
-                style="text-decoration: none; color: white"
+              <a href="pages/todolist.html" class="footer-link"
                 ><i
                   class="fas fa-tasks"
                   style="color: #e91e63; margin-right: 10px"

--- a/styling/styles.css
+++ b/styling/styles.css
@@ -831,7 +831,6 @@ body {
   );
 }
 
-
 .footer-top {
   display: grid;
   grid-template-columns: 2fr 1fr 1fr;
@@ -1558,7 +1557,6 @@ main {
   color: #444;
   margin-top: 0.5rem;
 }
- 
 
 /* ========== Scroll to Top Button ========== */
 #scrollToTopBtn {
@@ -1746,7 +1744,7 @@ main {
 
 .navbar-center {
   display: flex;
-  
+
   flex: 1;
   font-size: 1rem;
 }
@@ -1784,6 +1782,16 @@ main {
   display: none;
   font-size: 24px;
   cursor: pointer;
+}
+
+.footer-link {
+  text-decoration: none;
+  color: white;
+  transition: color 0.3s ease;
+}
+
+.footer-link:hover {
+  color: #e09e45;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
Fixes #526 

This PR adds a hover effect to the footer navigation links. Previously, the links had no visual feedback on hover, which affected user experience. Now, when a user hovers over a link, the text color transitions smoothly to #E09E45, improving interactivity and visual consistency.

Changes made:
- Removed inline `color` styles from `<a>` tags to avoid overriding class styles
- Added a `.footer-link` class in CSS with:
  - Base color: white
  - Hover color: #E09E45
  - Smooth transition for hover effect

Fixes: #526
[video.webm](https://github.com/user-attachments/assets/72cddaf6-27d9-4205-bba3-9f3e64d0af51)
