### PR TITLE
fix(#599): improve icon visibility in 'Why You Should Use NotesVault'…

### DIFF
--- a/styling/overview.css
+++ b/styling/overview.css
@@ -105,7 +105,7 @@
 
 .why-card i {
     font-size: 32px;
-    color: #163d3b;
+    color: orange;;
     margin-bottom: 15px;
 }
 
@@ -118,7 +118,7 @@
 
 .why-card p {
     font-size: 14px;
-    color: #555;
+    color: #f7f6f6;
 }
 .notesvault-section {
   padding: 30px;


### PR DESCRIPTION
### 🔧 Changes Made

- Improved the visibility of icons in the "Why You Should Use NotesVault" section.
- This addresses poor contrast and improves visual clarity, especially on light backgrounds.

### 📸 Screenshots (Before & After)

**Before:**
<img width="1277" height="385" alt="Screenshot 2025-08-04 at 12 19 08 PM" src="https://github.com/user-attachments/assets/2734cd74-d777-4ac7-a894-f59dd4e35541" />


**After:**
<img width="1280" height="370" alt="Screenshot 2025-08-04 at 12 18 41 PM" src="https://github.com/user-attachments/assets/febdc2a2-9e26-4c92-8e46-13b13c4c1241" />


### ✅ Closes Issue
Closes #599
