### PR TITLE
Fix: Made theme toggle available on all pages by adding navbar manually; attempted to add two new themes (blocked by existing CSS).

### DIFF
--- a/components/header.html
+++ b/components/header.html
@@ -5,10 +5,17 @@
 
     <!-- Navigation Menu -->
     <nav id="header-navigation" class="nav-menu">
-        <a href="overview.html">Overview</a>
+        <a href="../pages/overview.html">Overview</a>
         <a href="studentAccount.html">Student Account</a>
         <a href="about.html">About</a>
         <a href="features.html">Features</a>
+        <select id="theme-selector">
+    <option value="light">🌞 Light</option>
+    <option value="dark">🌙 Dark</option>
+    <option value="sepia">📜 Sepia</option>
+    <option value="contrast">⚡ High Contrast</option>
+</select>
+
     </nav>
 
     <div id="header-signup-box">

--- a/pages/BrowseNotes.html
+++ b/pages/BrowseNotes.html
@@ -14,7 +14,32 @@
 
     <!-- Header -->
     <header style="height: 100px;" id="header-holder">
+<nav>
+    <div id="header">
+        <div class="navbar-left">
+            <div class="logo nav-menu"><a href="index.html">NotesVault</a></div>
+        </div>
 
+        <!-- Navigation Menu -->
+        <nav id="header-navigation" class="nav-menu">
+            <a href="../pages/overview.html">Overview</a>
+            <a href="studentAccount.html">Student Account</a>
+            <a href="about.html">About</a>
+            <a href="features.html">Features</a>
+            <select id="theme-selector">
+                <option value="light">🌞 Light</option>
+                <option value="dark">🌙 Dark</option>
+                <option value="sepia">📜 Sepia</option>
+                <option value="contrast">⚡ High Contrast</option>
+            </select>
+
+        </nav>
+
+        <div id="header-signup-box">
+            <p onclick="window.location.href='../pages/signup.html'">Sign Up</p>
+        </div>
+    </div>
+</nav>
     </header>
 
 

--- a/pages/about.html
+++ b/pages/about.html
@@ -19,12 +19,40 @@
       src="https://js.sentry-cdn.com/8994bf86fecf7733832520db1565ab1f.min.js"
       crossorigin="anonymous"
     ></script>
+    <link rel="stylesheet" href="styling/themes.css">
+    <script src="../scripts/theme.js" defer></script>
   </head>
   <body>
     <!-- Header -->
     <header style="height: 100px;" id="header-holder">
+<nav>
+    <div id="header">
+        <div class="navbar-left">
+            <div class="logo nav-menu"><a href="index.html">NotesVault</a></div>
+        </div>
 
+        <!-- Navigation Menu -->
+        <nav id="header-navigation" class="nav-menu">
+            <a href="../pages/overview.html">Overview</a>
+            <a href="studentAccount.html">Student Account</a>
+            <a href="about.html">About</a>
+            <a href="features.html">Features</a>
+            <select id="theme-selector">
+                <option value="light">🌞 Light</option>
+                <option value="dark">🌙 Dark</option>
+                <option value="sepia">📜 Sepia</option>
+                <option value="contrast">⚡ High Contrast</option>
+            </select>
+
+        </nav>
+
+        <div id="header-signup-box">
+            <p onclick="window.location.href='../pages/signup.html'">Sign Up</p>
+        </div>
+    </div>
+</nav>
     </header>
+
 
     <div class="main_content">
       <!-- Hero Section -->

--- a/pages/features.html
+++ b/pages/features.html
@@ -7,6 +7,8 @@
   <link rel="icon" href="favicon.png" type="image/x-icon"/>
   <link rel="stylesheet" href="../components/header.css"/>
   <script src="../components/header.js"></script>
+  <link rel="stylesheet" href="styling/themes.css">
+  <script src="../scripts/theme.js" defer></script>
   <style>
     body {
       margin: auto;

--- a/pages/index.html
+++ b/pages/index.html
@@ -22,7 +22,32 @@
   <body>
     <!-- Header -->
     <header style="height: 100px;" id="header-holder">
+<nav>
+    <div id="header">
+        <div class="navbar-left">
+            <div class="logo nav-menu"><a href="index.html">NotesVault</a></div>
+        </div>
 
+        <!-- Navigation Menu -->
+        <nav id="header-navigation" class="nav-menu">
+            <a href="../pages/overview.html">Overview</a>
+            <a href="studentAccount.html">Student Account</a>
+            <a href="about.html">About</a>
+            <a href="features.html">Features</a>
+            <select id="theme-selector">
+                <option value="light">🌞 Light</option>
+                <option value="dark">🌙 Dark</option>
+                <option value="sepia">📜 Sepia</option>
+                <option value="contrast">⚡ High Contrast</option>
+            </select>
+
+        </nav>
+
+        <div id="header-signup-box">
+            <p onclick="window.location.href='../pages/signup.html'">Sign Up</p>
+        </div>
+    </div>
+</nav>
     </header>
 
     <!-- Main Section -->

--- a/pages/overview.html
+++ b/pages/overview.html
@@ -19,6 +19,9 @@
         crossorigin="anonymous"></script>
     <link rel="stylesheet" href="../components/header.css"/>
     <script src="../components/header.js"></script>
+    <link rel="stylesheet" href="styling/themes.css">
+    <script src="../scripts/theme.js" defer></script>
+
 </head>
 
 <body>
@@ -26,7 +29,32 @@
     <header style="height: 100px;" id="header-holder">
 
     </header>
+<nav>
+    <div id="header">
+        <div class="navbar-left">
+            <div class="logo nav-menu"><a href="index.html">NotesVault</a></div>
+        </div>
 
+        <!-- Navigation Menu -->
+        <nav id="header-navigation" class="nav-menu">
+            <a href="../pages/overview.html">Overview</a>
+            <a href="studentAccount.html">Student Account</a>
+            <a href="about.html">About</a>
+            <a href="features.html">Features</a>
+            <select id="theme-selector">
+                <option value="light">🌞 Light</option>
+                <option value="dark">🌙 Dark</option>
+                <option value="sepia">📜 Sepia</option>
+                <option value="contrast">⚡ High Contrast</option>
+            </select>
+
+        </nav>
+
+        <div id="header-signup-box">
+            <p onclick="window.location.href='../pages/signup.html'">Sign Up</p>
+        </div>
+    </div>
+</nav>
     <!-- Main Content Section -->
     <main>
         <!-- Hero Section -->

--- a/pages/studentAccount.html
+++ b/pages/studentAccount.html
@@ -8,6 +8,8 @@
   <link rel="icon" href="favicon.png" type="image/x-icon">
   <link rel="stylesheet" href="../components/header.css"/>
   <script src="../components/header.js"></script>
+  <link rel="stylesheet" href="styling/themes.css">
+  <script src="../scripts/theme.js" defer></script>
 </head>
 <body>
 

--- a/pages/todolist.html
+++ b/pages/todolist.html
@@ -17,7 +17,32 @@
 <body>
   <!-- Header -->
   <header style="height: 100px;" id="header-holder">
+<nav>
+    <div id="header">
+        <div class="navbar-left">
+            <div class="logo nav-menu"><a href="index.html">NotesVault</a></div>
+        </div>
 
+        <!-- Navigation Menu -->
+        <nav id="header-navigation" class="nav-menu">
+            <a href="../pages/overview.html">Overview</a>
+            <a href="studentAccount.html">Student Account</a>
+            <a href="about.html">About</a>
+            <a href="features.html">Features</a>
+            <select id="theme-selector">
+                <option value="light">🌞 Light</option>
+                <option value="dark">🌙 Dark</option>
+                <option value="sepia">📜 Sepia</option>
+                <option value="contrast">⚡ High Contrast</option>
+            </select>
+
+        </nav>
+
+        <div id="header-signup-box">
+            <p onclick="window.location.href='../pages/signup.html'">Sign Up</p>
+        </div>
+    </div>
+</nav>
   </header>
 
   <!-- Main Content -->

--- a/scripts/overview_darktheme.js
+++ b/scripts/overview_darktheme.js
@@ -1,24 +1,18 @@
+// Theme selector logic
+document.addEventListener("DOMContentLoaded", () => {
+    const themeSelector = document.getElementById("theme-selector");
+    const savedTheme = localStorage.getItem("theme") || "light";
 
-document.addEventListener('DOMContentLoaded', () => {
-    function toggleTheme() {
-        const html = document.documentElement;
-        const currentTheme = html.getAttribute('data-theme') || 'light';
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        html.setAttribute('data-theme', newTheme);
-        localStorage.setItem('theme', newTheme);
+    // Apply saved theme
+    document.documentElement.setAttribute("data-theme", savedTheme);
+    if (themeSelector) themeSelector.value = savedTheme;
+
+    // Change event listener
+    if (themeSelector) {
+        themeSelector.addEventListener("change", () => {
+            const theme = themeSelector.value;
+            document.documentElement.setAttribute("data-theme", theme);
+            localStorage.setItem("theme", theme);
+        });
     }
-
-    function initTheme() {
-        const savedTheme = localStorage.getItem('theme');
-        const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
-        document.documentElement.setAttribute('data-theme', savedTheme || (prefersDark ? 'dark' : 'light'));
-    }
-
-    const themeToggleButton = document.getElementById('themeToggle');
-    if (themeToggleButton) {
-        themeToggleButton.addEventListener('click', toggleTheme);
-    }
-
-    initTheme();
 });
-

--- a/scripts/theme.js
+++ b/scripts/theme.js
@@ -1,0 +1,14 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const themeSelector = document.getElementById("theme-selector");
+    if (!themeSelector) return;
+
+    const savedTheme = localStorage.getItem("theme") || "light";
+    document.documentElement.setAttribute("data-theme", savedTheme);
+    themeSelector.value = savedTheme;
+
+    themeSelector.addEventListener("change", () => {
+        const theme = themeSelector.value;
+        document.documentElement.setAttribute("data-theme", theme);
+        localStorage.setItem("theme", theme);
+    });
+});

--- a/styling/themes.css
+++ b/styling/themes.css
@@ -1,0 +1,80 @@
+/* Light Theme */
+:root {
+    --bg-color: #ffffff;
+    --text-color: #000000;
+    --header-footer-bg: #f5f5f5;
+    --card-bg: #ffffff;
+    --link-color: #007BFF;
+    --button-bg: #007BFF;
+    --button-text: #ffffff;
+}
+
+/* Dark Theme */
+[data-theme="dark"] {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    --header-footer-bg: #1e1e1e;
+    --card-bg: #1c1c1c;
+    --link-color: #66ccff;
+    --button-bg: #ff4081;
+    --button-text: #ffffff;
+}
+
+/* Sepia Theme */
+[data-theme="sepia"] {
+    --bg-color: #f4ecd8;
+    --text-color: #5b4636;
+    --header-footer-bg: #e6d3b3;
+    --card-bg: #f2e2c4;
+    --link-color: #8b4513;
+    --button-bg: #d2691e;
+    --button-text: #ffffff;
+}
+
+/* High Contrast Theme */
+[data-theme="contrast"] {
+    --bg-color: #000000;
+    --text-color: #ffff00;
+    --header-footer-bg: #000000;
+    --card-bg: #000000;
+    --link-color: #00ffff;
+    --button-bg: #ff00ff;
+    --button-text: #000000;
+}
+
+/* Apply styles globally */
+html, body {
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color);
+    color: var(--text-color);
+    font-family: Arial, sans-serif;
+    transition: background-color 0.3s, color 0.3s;
+}
+
+a {
+    color: var(--link-color);
+}
+
+#header, footer {
+    background-color: var(--header-footer-bg);
+    color: var(--text-color);
+    padding: 1rem;
+}
+
+.card {
+    background-color: var(--card-bg);
+    color: var(--text-color);
+    padding: 1rem;
+    border-radius: 8px;
+    margin: 0.5rem;
+}
+
+button {
+    background-color: var(--button-bg);
+    color: var(--button-text);
+    border: none;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    border-radius: 4px;
+}


### PR DESCRIPTION
While exploring the app as a user, I noticed that the dark/light toggle option existed in the code but wasn’t visible or functional on most pages. Upon investigation, I found that the header.html (containing the navbar) wasn’t being correctly loaded across all pages, which prevented users from accessing the theme toggle.

To fix this, I manually added the navbar code to all pages so that the theme selector is consistently available. After this change, users can successfully switch themes on any page.

I also attempted to add two new themes, but existing CSS styling conflicts prevented them from rendering as intended.