### PR TITLE
Remove Theme Toggle Button from Navbar on Tablet View to Avoid Duplication

### DIFF
--- a/styling/header.css
+++ b/styling/header.css
@@ -383,6 +383,10 @@
     display: flex;
   }
 
+  .navbar-actions {
+    display: none;
+  }
+
   .navbar-container {
     padding: 0 1.5rem;
   }


### PR DESCRIPTION
## Solved #708

### **Problem:**
The theme toggle button was duplicated in the mobile/tablet layout:
- One in the **navbar**
- One in the **dropdown menu** (or dashboard section)

Both were visible in **tablet view**, leading to unnecessary redundancy and clutter in the UI.

### **Solution:**
- **Removed** the theme toggle button from the **navbar** when in tablet view to avoid duplication.
- The toggle button will now only appear in the **dropdown/dashboard section**, ensuring a cleaner an

d more intuitive user interface.

### **Changes Made:**
- Applied a **CSS media query** to target tablet view and hide the theme toggle button in the **navbar** (screen width ≤ 768px).
- The button remains visible in the **dropdown** for mobile and tablet view.

###**Before Changes**

<img width="893" height="876" alt="screenshot-1755256551584" src="https://github.com/user-attachments/assets/2a73df67-376a-49db-998e-d4f934805773" />

###**After Changes**
<img width="893" height="876" alt="afterChanges" src="https://github.com/user-attachments/assets/7a5d38a7-8674-47f3-8d40-a30631920030" />


Please review the changes. Looking forward to feedback! ✨
