### PR TITLE
Jotpad placeholder text bug fixed

### DIFF
--- a/scripts/jotpad.js
+++ b/scripts/jotpad.js
@@ -1,6 +1,6 @@
 // JotPad (JavaScript)
 
-ocument.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', function () {
   const noteArea = document.getElementById('noteArea')
   noteArea.innerHTML = localStorage.getItem('noteContent') || ''
 


### PR DESCRIPTION
## Summary

Fixed an issue where the placeholder text ("Start typing here...") didn't disappear after typing.  
The problem was caused by a spelling error that prevented the script from running.

This improvement was made as part of the **OSconnect** open-source event, which I participated in.

---

## Changes

- **Spelling Error Fix**: Corrected a typo in the JavaScript, allowing the script to run and toggle the `empty` class correctly.
- **Placeholder Behavior**: Once the script ran, the placeholder text now disappears as expected when the user starts typing.

---

## Why It Was Happening

The script was not executing due to a spelling error in the JavaScript file, which prevented the placeholder behavior logic from working correctly.

---
<img width="1920" height="985" alt="ResolvedStartTypingHere" src="https://github.com/user-attachments/assets/dacd110c-b0db-44df-b3db-d97d7ecf1a5b" />


**Resolved**: `StartTypingHere`  
**Closes**: #717
