### PR TITLE
Add Counting Animation to About Us Page Stats

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -267,3 +267,46 @@ document.addEventListener('DOMContentLoaded', () => {
 
   init()
 })
+
+document.addEventListener('DOMContentLoaded', () => {
+  const statsSection = document.querySelector('.about-hero');
+  const statNumbers = document.querySelectorAll('.stat-number[data-count]');
+  let animationStarted = false;
+
+  const startCountingAnimation = () => {
+    statNumbers.forEach(statNumber => {
+      const target = parseInt(statNumber.dataset.count);
+      let current = 0;
+      const duration = 2000; // 2 seconds
+      const increment = target / (duration / 10);
+
+      const updateCounter = () => {
+        current += increment;
+        if (current < target) {
+          statNumber.textContent = Math.ceil(current);
+          requestAnimationFrame(updateCounter);
+        } else {
+          statNumber.textContent = `${target}+`;
+        }
+      };
+
+      updateCounter();
+    });
+  };
+
+  const observer = new IntersectionObserver((entries, observer) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting && !animationStarted) {
+        startCountingAnimation();
+        animationStarted = true;
+        observer.unobserve(entry.target);
+      }
+    });
+  }, {
+    threshold: 0.5 // Trigger when 50% of the section is visible
+  });
+
+  if (statsSection) {
+    observer.observe(statsSection);
+  }
+});


### PR DESCRIPTION
Issue Reference: #393
This PR enhances the About Us page by adding a dynamic counting animation to the hero stats section.
Previously, the stats (Notes Shared, Contributors, Available) displayed as static numbers. Now, when the user scrolls the section into view, the numbers smoothly animate from 0 up to their target values.
<img width="1902" height="654" alt="image" src="https://github.com/user-attachments/assets/65271d36-0b20-4964-b1a4-9f2cb0a3e2a3" />
