### PR TITLE
fixed filter container alignment in small screens

### DIFF
--- a/styling/notes.css
+++ b/styling/notes.css
@@ -292,7 +292,7 @@
 
 @media (max-width: 600px) {
   .filters-container {
-    align-items: center;
+    align-items: left;
   }
 
   .modal-content {


### PR DESCRIPTION
<img width="316" height="550" alt="Screenshot 2025-08-23 125319" src="https://github.com/user-attachments/assets/207eb39a-9fc0-407c-bc9f-6db12b9d8fc3" />
<img width="255" height="518" alt="Screenshot 2025-08-23 130009" src="https://github.com/user-attachments/assets/f008ae40-1caf-434b-b2c6-87c4ad3b8ccc" />



Fixed the misalignment of filter container for small screens !