### PR TITLE
Fix: Update hero greeting & CTA based on auth state (#765)

### DIFF
--- a/pages/index.html
+++ b/pages/index.html
@@ -39,7 +39,7 @@
       <section class="hero">
         <div class="container">
           <div class="hero-content">
-            <p class="welcome-text">Welcome Back</p>
+            <p class="welcome-text">Welcome to NotesVault</p>
             <h1>Your Organized <span class="text-accent">Learning Companion...</span></h1>
             <p class="subtext">
               Keep your study notes and PYQs organized, easy to find, and always

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -34,6 +34,28 @@ document.addEventListener('DOMContentLoaded', () => {
 
     return container.firstElementChild
   }
+     
+     const updateWelcomeUI = () => {
+     const user = localStorage.getItem('nv_user');                      // truthy = logged in
+     const userName = (localStorage.getItem('nv_user_name') || '').trim();
+     const welcomeText = document.querySelector('.welcome-text');
+     const primaryCTA = document.querySelector('.cta-buttons .btn.btn-primary'); // Upload/Sign Up button
+
+    // If elements aren't present on this page, do nothing
+      if (!welcomeText || !primaryCTA) return;
+
+    if (user) {
+    // logged in
+    welcomeText.textContent = userName ? `Welcome back, ${userName}` : 'Welcome back';
+    primaryCTA.setAttribute('href', 'upload.html');
+    primaryCTA.innerHTML = '<i class="fas fa-upload"></i>Upload Notes';
+  } else {
+    // logged out
+    welcomeText.textContent = 'Welcome to NotesVault';
+    primaryCTA.setAttribute('href', 'signup.html');
+    primaryCTA.innerHTML = '<i class="fas fa-user-plus"></i>Sign Up';
+  }
+};
 
   // Search Function //
   const updateSemesters = () => {
@@ -263,6 +285,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Load Back To Top Button
     DOM.backToTop = document.querySelector('.back-to-top')
     setupBackToTop()
+    // Update hero greeting & CTA based on auth
+    updateWelcomeUI();
+
   }
 
   init()


### PR DESCRIPTION
**Issue Fixed:** #765

**What changed**
- Replaced hard-coded “Welcome Back” with neutral “Welcome to NotesVault” for logged-out users.
- Added JS check using localStorage keys `nv_user` and `nv_user_name`.
- CTA logic:
  - Logged out → “Sign Up” (href: signup.html)
  - Logged in → “Upload Notes” (href: upload.html), greeting “Welcome back, <name>” when available.

**Why**
Prevents confusing message for first-time/logged-out users; improves onboarding clarity.

**How I tested**
1) Incognito / cleared storage → shows “Welcome to NotesVault” + “Sign Up”.
2) Console:
   ```js
   localStorage.setItem('nv_user','1');
   localStorage.setItem('nv_user_name','Gourangi');
   location.reload();
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/53539362-7132-4d14-8922-980c7859869a" />
→ shows “Welcome back, Gourangi” + “Upload Notes”.

localStorage.removeItem('nv_user');
localStorage.removeItem('nv_user_name');
location.reload();

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/baef8f58-8b4e-4639-902b-9f4e7dbb8981" />
→ returns to logged-out state.