### PR TITLE
Fix: hide Back-to-Top button when drawer/ footer is visible (#764)

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -159,13 +159,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const menuToggle = document.querySelector('.menu-toggle')
     const mobileNav = document.querySelector('.mobile-nav')
     const overlay = document.querySelector('.overlay')
+    const backToTop  = document.querySelector('.back-to-top');
 
     menuToggle?.classList.toggle('active')
     mobileNav?.classList.toggle('active')
     overlay?.classList.toggle('active')
-    document.body.style.overflow = mobileNav?.classList.contains('active')
-      ? 'hidden'
-      : ''
+
+    const isOpen = mobileNav?.classList.contains('active');      // ✅ define it
+    document.body.style.overflow = isOpen ? 'hidden' : '';       // lock/unlock scroll
+    document.body.classList.toggle('drawer-open', isOpen);       // ✅ add/remove class
+
+    // hide the back-to-top while drawer is open
+    if (backToTop && isOpen) backToTop.classList.remove('visible');
+    
   }
 
   const setupMobileMenu = () => {
@@ -184,7 +190,20 @@ document.addEventListener('DOMContentLoaded', () => {
   const setupBackToTop = () => {
     if (!DOM.backToTop) return
     window.addEventListener('scroll', () => {
-      DOM.backToTop.classList.toggle('visible', window.scrollY > 300)
+      const footer = document.querySelector('footer')
+      const backToTop = document.querySelector('.back-to-top')
+
+      if (!footer || !backToTop) return
+
+      const footerRect = footer.getBoundingClientRect()
+      const isFooterVisible = footerRect.top < window.innerHeight
+
+      // Show/hide button based on scroll position AND footer visibility
+      if (window.scrollY > 300 && !isFooterVisible) {
+        backToTop.classList.add('visible')
+      } else {
+        backToTop.classList.remove('visible')
+      }
     })
 
     DOM.backToTop.addEventListener('click', () => {

--- a/styling/base.css
+++ b/styling/base.css
@@ -102,3 +102,101 @@ a:hover {
 .text-center {
   text-align: center;
 }
+/* Hide Back-to-Top whenever the mobile drawer is open */
+.drawer-open .back-to-top {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity .2s ease, visibility 0s linear .2s;
+}
+
+/* ensure drawer sits above the button */
+/* header toggle stays clickable */
+.menu-toggle {
+  position: relative;
+  z-index: 1100;
+}
+
+/* overlay: covers the page, below the drawer */
+.overlay {
+  position: fixed;
+  inset: 0;                    /* top/right/bottom/left:0 */
+  background: rgba(0,0,0,.45);
+  z-index: 900;                /* < drawer (1000), > page */
+  opacity: 0;
+  pointer-events: none;        /* not clickable until active */
+  transition: opacity .2s ease;
+}
+.overlay.active {
+  opacity: 1;
+  pointer-events: auto;        /* click to close */
+}
+
+/* drawer: on top of overlay */
+.mobile-nav {
+  position: fixed;
+  top: 0;
+  right: 0;                    /* (use left:0 if your drawer slides from left) */
+  width: 80vw;
+  max-width: 420px;
+  height: 100vh;
+  background: var(--bg-primary);
+  overflow: auto;              /* menu can scroll internally */
+  z-index: 1000;               /* above overlay (900) */
+  transform: translateX(100%); /* closed state (from right) */
+  transition: transform .25s ease;
+}
+.mobile-nav.active {
+  transform: translateX(0);    /* open */
+}
+
+
+/* bump mobile spacing a bit more to avoid bottom UI */
+@media (max-width: 600px) {
+  .back-to-top {
+    bottom: 120px; /* was 100px */
+  }
+}
+
+/* Back to Top Button */
+.back-to-top {
+  position: fixed;
+  bottom: 80px; /* Safe distance from bottom on desktop */
+  right: 2rem;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background-color: var(--primary-500);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(1rem);
+  transition: all 0.3s ease;
+  z-index: 99; /* Lower than modals (100) but above content */
+  box-shadow: 0 4px 15px rgba(0, 140, 45, 0.3);
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.back-to-top:hover {
+  background-color: var(--primary-600);
+  transform: translateY(-3px);
+}
+
+
+
+
+/* Footer interaction */
+.footer-visible .back-to-top {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.3s ease, visibility 0s linear 0.3s;
+}


### PR DESCRIPTION
**Issue Fixed:** #764  

### 🔧 What Changed
- Added CSS rule `.drawer-open .back-to-top` to hide the button whenever the mobile drawer is open.  
- Adjusted z-index layering so:
  - Drawer (`.mobile-nav`) sits above overlay.  
  - Overlay covers background but not the drawer.  
  - Back-to-Top stays below both.  
- Updated JavaScript toggle to:
  - Add/remove `drawer-open` on `<body>`.  
  - Ensure Back-to-Top hides while drawer is active.  
- Footer interaction preserved → button hides when footer enters view.  

### ✅ Behavior After Fix
- **Desktop:** Back-to-Top works as before (appears on scroll, hides near footer).  
- **Mobile:**  
  - Opening the hamburger menu hides Back-to-Top.  
  - Closing the menu restores it (if scroll conditions are met).  
  - Button no longer overlaps footer links or drawer UI.  

---

This PR resolves Issue #764 🚀
<img width="602" height="771" alt="image" src="https://github.com/user-attachments/assets/e7cc230c-c9ce-4abc-afb2-f1af1f4b6d0f" />

<img width="622" height="774" alt="image" src="https://github.com/user-attachments/assets/fec5ca62-3a65-425b-bb8e-f3047b7835e6" />
