### PR TITLE
Fix: Added forgot-password.html placeholder page and updated login flow

### DIFF
--- a/pages/forgot-password.html
+++ b/pages/forgot-password.html
@@ -1,0 +1,66 @@
+<!-- Forgot Password (HTML) -->
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NotesVault - Forgot Password</title>
+
+    <!-- Favicon -->
+    <link rel="icon" href="../assets/index/images/favicon.png" type="image/x-icon" />
+
+    <!-- Font Awesome -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
+    />
+
+    <!-- CSS -->
+    <link rel="stylesheet" href="../styling/login.css" />
+    <link rel="stylesheet" href="../styling/base.css" />
+    <link rel="stylesheet" href="../styling/variables.css" />
+  </head>
+
+  <body class="login-page">
+    <!-- Back Button -->
+    <a href="login.html" class="floating-back-btn">
+      <i class="fas fa-chevron-left"></i>
+      <span>Back</span>
+    </a>
+
+    <div class="login-card">
+      <div class="login-header">
+        <div class="logo-preview">
+          <i class="fas fa-lock"></i>
+        </div>
+        <h2>Forgot Password</h2>
+        <p>Enter your registered email to reset your password</p>
+      </div>
+
+      <form id="forgotPasswordForm" class="login-form">
+        <div class="form-group floating-input">
+          <input
+            type="email"
+            id="email"
+            name="email"
+            required
+            placeholder=" "
+            autocomplete="username"
+          />
+          <label for="email">Email address</label>
+          <div class="input-border"></div>
+        </div>
+
+        <button type="submit" class="btn btn-primary" disabled>
+          <span>Reset Password (Coming Soon)</span>
+          <i class="fas fa-envelope btn-icon"></i>
+        </button>
+      </form>
+
+      <div class="signup-link">
+        <p>Remembered your password? <a href="login.html">Sign in</a></p>
+      </div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Description
Fixed the issue where clicking the “Forgot Password” link on the login.html page resulted in a 404 Page Not Found error.
A new forgot-password.html page has been created as a placeholder until the password reset functionality is implemented.

### Changes
- Added new `forgot-password.html` placeholder page.
- Styled the page consistently using existing CSS.
- Updated the link to correctly open the new page.

### Screenshots
**Before:** 404 Page Not Found  
<img width="1655" height="933" alt="image" src="https://github.com/user-attachments/assets/52235390-f214-48ec-990e-7454ab7405f2" />

**After:** Forgot Password page opens with placeholder content.
<img width="1650" height="961" alt="image" src="https://github.com/user-attachments/assets/31724200-cc6a-41d3-b77f-372ef7612738" />


@adityai0 please review it and merge this PR.

## Program
This contribution is made under GSSoC