### PR TITLE
Fix duplicate Privacy Policy link in footer and ensure CSS applies

### DIFF
--- a/components/footer.html
+++ b/components/footer.html
@@ -147,9 +147,10 @@
           <span class="heart">❤️</span> by the Open Source Community
         </p>
         <div class="legal-links">
-          <a href="../pages/privacy-policy.html" class="legal-link">Privacy Policy</a>
           <span class="divider">•</span>
           <a href="../pages/terms-of-service.html" class="legal-link">Terms of Service</a>
+          <span class="divider">•</span>
+          <a href="../pages/privacy-policy.html" class="legal-link">Privacy Policy</a>
           <span class="divider">•</span>
           <a
             href="https://opensource.org/licenses/MIT"

--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NotesVault - Privacy Policy</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
-    <link rel="stylesheet" href="../styling/privacy-policy.css">
+    <link rel="stylesheet" href="/styling/privacy-policy.css">
 </head>
 <body>
     <div class="privacy_policy_container">


### PR DESCRIPTION
Fixes #994 
## Description
Fixed the issue of duplicate Privacy Policy links appearing in the footer on the deployed site.
- Previously, the footer was displaying 2 Privacy Policy links, and the styling (CSS) was not applied correctly. 
- After the fix, the footer now shows 1 Privacy Policy link and the CSS is correctly applied.

## Screenshots

### Footer Issue: Before and After Fix

| Page / Section        | Before Fix | After Fix |
|----------------------|------------|-----------|
| Footer on Deployed Page | <img  alt="b2" src="https://github.com/user-attachments/assets/8d6c329c-5f14-44ef-8fa4-dec57b608e27" /> | <img  alt="n2" src="https://github.com/user-attachments/assets/7f69ae32-3cb3-443e-ae5c-c015fca3c8a3" /> |
| Footer CSS on Deployed Page  | <img width="400" alt="b1" src="https://github.com/user-attachments/assets/da88f4e6-489a-4118-838b-622ffe3abd7c" /> | <img width="400" alt="n1" src="https://github.com/user-attachments/assets/f9eb84d4-f57e-4599-8029-6ed46bf798ab" /> |
