### PR TITLE
fix: added smooth fade transition between pages to reduce white flash

### DIFF
--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,4 +1,18 @@
 document.addEventListener('DOMContentLoaded', () => {
+  document.body.classList.add("fade-in");
+document.querySelectorAll('a').forEach(link => {
+  const href = link.getAttribute('href');
+  if (!href || href.startsWith('#') || href.startsWith('javascript:')) return;
+  link.addEventListener('click', e => {
+    if (link.target === '_blank' || link.hasAttribute('download')) return;
+    e.preventDefault();
+    document.body.classList.add('fade-out');
+    setTimeout(() => {
+      window.location.href = href;
+    }, 300); 
+  });
+});
+
   const DOM = {
     searchBranchContainer: document.getElementById('search-parameters-branch'),
     searchSemesterContainer: document.getElementById('search-parameters-semester'),
@@ -8,6 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
     yearElement: document.getElementById('year'),
     backToTop: document.querySelector('.back-to-top'),
   }
+  
 
   const TYPEWRITER_WORDS = ['Branch', 'Semester', 'Subject', 'Year']
   let allData = { branches: [] }
@@ -16,7 +31,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (!container) return null
     container.innerHTML = `
       <select id="${id}" class="search-parameters-select" aria-label="${placeholder}">
-        <option value="" disabled selected>${placeholder}</option>
+        <option value="" disabledselected>${placeholder}</option>
         ${options.map((opt) => `<option value="${opt}">${opt}</option>`).join('')}
       </select>
     `

--- a/styling/base.css
+++ b/styling/base.css
@@ -12,8 +12,17 @@ body {
   color: var(--text-primary);
   line-height: 1.6;
   margin: 3rem 0 0 0;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
 }
+body.fade-in {
+  opacity: 1;
+}
+body.fade-out {
+  opacity: 0;
+  transition: opacity 0.3s ease-in-out;
+}
+
 
 /* Typography */
 h1,


### PR DESCRIPTION
Implemented a smooth fade-in/out transition for page navigation

Details
- Updated `base.css` to include fade-in/out animations.
- Modified `script.js` to trigger fade-out before navigation and fade-in on page load.
